### PR TITLE
Configure button as active low

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Create `include/secrets.h` with your WiFi credentials as `WIFI_SSID` and
 - OTA updates over WiFi
 - Simple WebSocket API for remote control
 
+### Hardware
+The previous and next buttons are wired as active-low and rely on the microcontroller's internal pull-up resistors.
+
 ### Building
 Run `setup.sh` once to install PlatformIO and build the firmware:
 

--- a/src/goggles.ino
+++ b/src/goggles.ino
@@ -191,7 +191,8 @@ void wsEvent(uint8_t num, WStype_t type, uint8_t *payload, size_t len) {
 void setup() {
   Serial.begin(115200);
   pinMode(cfg::BTN_PREV, INPUT_PULLUP);
-  pinMode(cfg::BTN_NEXT, INPUT);
+  // Buttons use internal pull-ups and are thus active-low
+  pinMode(cfg::BTN_NEXT, INPUT_PULLUP);
   FastLED.addLeds<WS2812, cfg::LED_PIN, GRB>(leds, cfg::NUM_LEDS);
 
   connectWiFi();


### PR DESCRIPTION
## Summary
- enable pull-up on BTN_NEXT and clarify active-low behaviour
- document active-low buttons in README

## Testing
- `./setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_68437a5c76f0833293c6a4a14ecc9adc