### PR TITLE
Add WebSocket docs and preset comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@ credentials as `WIFI_SSID` and `WIFI_PASSWORD`.
 ### Hardware
 The previous and next buttons are wired as active-low and rely on the microcontroller's internal pull-up resistors.
 
+### WebSocket API
+The firmware also runs a WebSocket server on port `81`. Send plain text commands
+to control the active preset. Example using [`wscat`](https://github.com/websockets/wscat):
+
+```bash
+wscat -c ws://<device_ip>:81/ -x next
+```
+
+Available commands:
+
+* `next` &mdash; switch to the next preset.
+* `prev` &mdash; switch to the previous preset.
+* `set:<n>` &mdash; activate the preset with index `<n>` (zero based), e.g. `set:0`.
+
 ### Building
 Run `setup.sh` once to install PlatformIO and build the firmware:
 

--- a/src/goggles.ino
+++ b/src/goggles.ino
@@ -22,6 +22,16 @@ const char *SSID = WIFI_SSID;
 const char *PASSWORD = WIFI_PASSWORD;
 } // namespace cfg
 
+/**
+ * Types of LED animations.
+ *
+ * - `STATIC`     Solid color chosen per preset
+ * - `RAINBOW`    Continuously cycling rainbow
+ * - `POLICE_NL`  Blue and white pattern similar to Dutch police lights
+ * - `POLICE_USA` Red, white and blue pattern similar to US police lights
+ * - `STROBE`     Fast white flash on and off
+ * - `LAVALAMP`   Slowly moving color gradient
+ */
 enum class PresetType {
   STATIC,
   RAINBOW,


### PR DESCRIPTION
## Summary
- document `PresetType` enum values in `src/goggles.ino`
- expand README with a WebSocket API section and usage example

## Testing
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_6843e45e5d908332a20d2dd18ba42117