### PR TITLE
Check for secrets file before building firmware

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -9,5 +9,12 @@ if ! command -v pio >/dev/null 2>&1; then
     export PATH="$PATH:$(python3 -m site --user-base)/bin"
 fi
 
+# Verify secrets.h exists before building
+if [ ! -f include/secrets.h ]; then
+    echo "Error: include/secrets.h not found." >&2
+    echo "Copy include/secrets_example.h to include/secrets.h and set your WiFi credentials." >&2
+    exit 1
+fi
+
 # Build firmware
 pio run


### PR DESCRIPTION
## Summary
- verify `include/secrets.h` exists in `setup.sh`
- print message instructing to copy `include/secrets_example.h` if missing

## Testing
- `./setup.sh` (with a dummy `pio` binary)

------
https://chatgpt.com/codex/tasks/task_e_6843e4608c688332a231f829dcb4a604