### PR TITLE
Add color parsing tests and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Build and Test
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install PlatformIO
+        run: pip install platformio
+      - name: Prepare secrets
+        run: cp include/secrets_example.h include/secrets.h
+      - name: Run tests
+        run: pio test
+      - name: Build firmware
+        run: pio run

--- a/platformio.ini
+++ b/platformio.ini
@@ -7,3 +7,6 @@ lib_deps =
     fastled
     links2004/WebSockets
 
+[test]
+test_build_src = yes
+

--- a/src/goggles.ino
+++ b/src/goggles.ino
@@ -51,6 +51,9 @@ unsigned long lastAnim = 0;
 WebServer server(80);
 WebSocketsServer ws(81);
 
+
+#include "utils.h"
+
 /**
  * Connect to WiFi using credentials from secrets.h
  */
@@ -184,25 +187,14 @@ void handleAdd() {
 
   String name = server.arg("name");
   String colorStr = server.arg("color");
-
-  if (colorStr.length() != 7 || colorStr[0] != '#') {
+  CRGB color;
+  if (!parseHexColor(colorStr, color)) {
     server.send(400, "text/html",
-                "<html><body><p>Color must be in format #RRGGBB.</p><a href='/' >Back</a></body></html>");
+                "<html><body><p>Color must be in format #RRGGBB and contain valid hex digits.</p><a href='/' >Back</a></body></html>");
     return;
   }
 
-  colorStr = colorStr.substring(1);
-  for (size_t i = 0; i < colorStr.length(); ++i) {
-    if (!isxdigit(static_cast<unsigned char>(colorStr[i]))) {
-      server.send(400, "text/html",
-                  "<html><body><p>Color contains invalid hex characters.</p><a href='/' >Back</a></body></html>");
-      return;
-    }
-  }
-
-  long val = strtol(colorStr.c_str(), nullptr, 16);
-  presets.push_back({name, PresetType::STATIC,
-                     CRGB((val >> 16) & 0xFF, (val >> 8) & 0xFF, val & 0xFF)});
+  presets.push_back({name, PresetType::STATIC, color});
   currentPreset = presets.size() - 1;
   applyPreset();
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <Arduino.h>
+#include <FastLED.h>
+#include <ctype.h>
+
+inline bool parseHexColor(const String &input, CRGB &out) {
+    if (input.length() != 7 || input[0] != '#')
+        return false;
+    String hex = input.substring(1);
+    for (size_t i = 0; i < hex.length(); ++i) {
+        if (!isxdigit(static_cast<unsigned char>(hex[i])))
+            return false;
+    }
+    long val = strtol(hex.c_str(), nullptr, 16);
+    out = CRGB((val >> 16) & 0xFF, (val >> 8) & 0xFF, val & 0xFF);
+    return true;
+}

--- a/test/test_color.cpp
+++ b/test/test_color.cpp
@@ -1,0 +1,33 @@
+#include <Arduino.h>
+#include <unity.h>
+#include <FastLED.h>
+#include "../src/utils.h"
+
+void test_parse_valid() {
+    CRGB c;
+    TEST_ASSERT_TRUE(parseHexColor("#1A2B3C", c));
+    TEST_ASSERT_EQUAL_UINT8(0x1A, c.r);
+    TEST_ASSERT_EQUAL_UINT8(0x2B, c.g);
+    TEST_ASSERT_EQUAL_UINT8(0x3C, c.b);
+}
+
+void test_parse_invalid_format() {
+    CRGB c;
+    TEST_ASSERT_FALSE(parseHexColor("123456", c));
+    TEST_ASSERT_FALSE(parseHexColor("#12345", c));
+}
+
+void test_parse_invalid_chars() {
+    CRGB c;
+    TEST_ASSERT_FALSE(parseHexColor("#ZZZZZZ", c));
+}
+
+void setup() {
+    UNITY_BEGIN();
+    RUN_TEST(test_parse_valid);
+    RUN_TEST(test_parse_invalid_format);
+    RUN_TEST(test_parse_invalid_chars);
+    UNITY_END();
+}
+
+void loop() {}


### PR DESCRIPTION
## Summary
- factor out color parsing into `parseHexColor`
- test `parseHexColor`
- run `pio test` and build firmware on PRs

## Testing
- `pio test --without-uploading` *(fails: Please specify `test_port`)*
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_6843e45ba91c8332b628f9747ace20c0