### PR TITLE
Add runtime WiFi configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 *.secret
 # PlatformIO build directory
 .pio/
+# Local WiFi credentials
+include/secrets.h
 
 
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ credentials as `WIFI_SSID` and `WIFI_PASSWORD`.
 - Web interface for switching LED presets
 - OTA updates over WiFi
 - Simple WebSocket API for remote control
+- Runtime WiFi configuration at `/wifi`
 
 ### Hardware
 The previous and next buttons are wired as active-low and rely on the microcontroller's internal pull-up resistors.

--- a/src/goggles.ino
+++ b/src/goggles.ino
@@ -10,6 +10,7 @@
 #include <WebServer.h>
 #include <WebSocketsServer.h>
 #include <WiFi.h>
+#include <Preferences.h>
 #include <vector>
 #include <ctype.h>
 
@@ -58,17 +59,40 @@ int currentPreset = 0;
 uint8_t rainbowHue = 0;
 unsigned long lastAnim = 0;
 
+Preferences prefs;
+String storedSSID;
+String storedPassword;
+
 WebServer server(80);
 WebSocketsServer ws(81);
 
+void loadCredentials() {
+  prefs.begin("wifi", true);
+  storedSSID = prefs.getString("ssid", "");
+  storedPassword = prefs.getString("pass", "");
+  prefs.end();
+}
+
+void saveCredentials(const String &ssid, const String &password) {
+  prefs.begin("wifi", false);
+  prefs.putString("ssid", ssid);
+  prefs.putString("pass", password);
+  prefs.end();
+  storedSSID = ssid;
+  storedPassword = password;
+}
+
 /**
- * Connect to WiFi using credentials from secrets.h
+ * Connect to WiFi using stored credentials if available
  */
 
 void connectWiFi() {
+  loadCredentials();
+  const char *ssid = storedSSID.length() ? storedSSID.c_str() : cfg::SSID;
+  const char *pass = storedPassword.length() ? storedPassword.c_str() : cfg::PASSWORD;
   WiFi.disconnect(true);
   WiFi.mode(WIFI_STA);
-  WiFi.begin(cfg::SSID, cfg::PASSWORD);
+  WiFi.begin(ssid, pass);
   unsigned long start = millis();
   Serial.print("Connecting to WiFi");
   while (WiFi.status() != WL_CONNECTED && millis() - start < 15000) {
@@ -166,6 +190,7 @@ const char HTML_FOOTER[] PROGMEM = R"html(
     </div>
     <button class='btn btn-primary'>Add</button>
   </form>
+  <a class='btn btn-link mt-2' href='/wifi'>WiFi setup</a>
 </body>
 </html>
 )html";
@@ -221,6 +246,42 @@ void handleAdd() {
 }
 
 /**
+ * Display form for WiFi credentials
+ */
+void handleWifiForm() {
+  String html =
+      "<!DOCTYPE html><html><head><title>WiFi Setup</title>"
+      "<link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css'></head>"
+      "<body class='container mt-4'>"
+      "<h1>WiFi Credentials</h1>"
+      "<form method='POST' action='/wifi'>"
+      "<div class='form-group'><label for='ssid'>SSID</label>"
+      "<input class='form-control' id='ssid' name='ssid' value='" +
+      storedSSID + "'></div>"
+      "<div class='form-group'><label for='password'>Password</label>"
+      "<input class='form-control' id='password' name='password' type='password' value='" +
+      storedPassword + "'></div>"
+      "<button class='btn btn-primary'>Save</button></form>"
+      "</body></html>";
+  server.send(200, "text/html", html);
+}
+
+/**
+ * Save WiFi credentials from form
+ */
+void handleWifiSave() {
+  if (!server.hasArg("ssid") || !server.hasArg("password")) {
+    server.send(400, "text/html",
+                "<html><body><p>Missing SSID or password.</p><a href='/wifi'>Back</a></body></html>");
+    return;
+  }
+  saveCredentials(server.arg("ssid"), server.arg("password"));
+  connectWiFi();
+  server.sendHeader("Location", "/");
+  server.send(303);
+}
+
+/**
  * Handle incoming WebSocket messages
  */
 void wsEvent(uint8_t num, WStype_t type, uint8_t *payload, size_t len) {
@@ -265,6 +326,8 @@ void setup() {
 
   server.on("/", handleRoot);
   server.on("/add", HTTP_POST, handleAdd);
+  server.on("/wifi", HTTP_GET, handleWifiForm);
+  server.on("/wifi", HTTP_POST, handleWifiSave);
   server.begin();
 
   ws.begin();


### PR DESCRIPTION
## Summary
- support storing WiFi credentials in NVS
- add web form at `/wifi` for updating SSID/password
- link to WiFi form from main page
- document new feature
- ignore local secrets.h

## Testing
- `./setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843e723a3208332a857cd47afd5823e