### PR TITLE
Add WebSocket commands for brightness, color and speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ to control the active preset. Example using [`wscat`](https://github.com/websock
 
 ```bash
 wscat -c ws://<device_ip>:81/ -x next
+# set brightness to half
+wscat -c ws://<device_ip>:81/ -x bright:128
 ```
 
 Available commands:
@@ -29,6 +31,9 @@ Available commands:
 * `next` &mdash; switch to the next preset.
 * `prev` &mdash; switch to the previous preset.
 * `set:<n>` &mdash; activate the preset with index `<n>` (zero based), e.g. `set:0`.
+* `bright:<0-255>` &mdash; set global LED brightness.
+* `color:#RRGGBB` &mdash; change the color of the active preset.
+* `speed:<ms>` &mdash; change animation update interval in milliseconds.
 
 ### Building
 Run `setup.sh` once to install PlatformIO and build the firmware:


### PR DESCRIPTION
## Summary
- allow changing LED brightness, color, and animation speed over WebSocket
- show usage of new commands in README

## Testing
- `./setup.sh` *(fails: include/secrets.h not found)*
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_6843e72b43d4833286c89593db2f217e