### PR TITLE
Use timers for animations

### DIFF
--- a/src/goggles.ino
+++ b/src/goggles.ino
@@ -56,7 +56,6 @@ std::vector<Preset> presets{{"White", PresetType::STATIC, CRGB::White},
 CRGB leds[cfg::NUM_LEDS];
 int currentPreset = 0;
 uint8_t rainbowHue = 0;
-unsigned long lastAnim = 0;
 
 WebServer server(80);
 WebSocketsServer ws(81);
@@ -91,14 +90,18 @@ void applyPreset() {
   case PresetType::STATIC:
     fill_solid(leds, cfg::NUM_LEDS, presets[currentPreset].color);
     break;
+
   case PresetType::RAINBOW:
-    fill_rainbow(leds, cfg::NUM_LEDS, rainbowHue++, 7);
+    EVERY_N_MILLISECONDS(50) { ++rainbowHue; }
+    fill_rainbow(leds, cfg::NUM_LEDS, rainbowHue, 7);
     break;
+
   case PresetType::POLICE_NL:
     for (int i = 0; i < cfg::NUM_LEDS; ++i) {
       leds[i] = (i % 4 < 2) ? CRGB::Blue : CRGB::White;
     }
     break;
+
   case PresetType::POLICE_USA:
     for (int i = 0; i < cfg::NUM_LEDS; ++i) {
       leds[i] = (i % 6 < 2)   ? CRGB::Red
@@ -106,19 +109,22 @@ void applyPreset() {
                               : CRGB::Blue;
     }
     break;
+
   case PresetType::STROBE: {
     static bool on = false;
+    EVERY_N_MILLISECONDS(50) { on = !on; }
     fill_solid(leds, cfg::NUM_LEDS, on ? CRGB::White : CRGB::Black);
-    on = !on;
   } break;
+
   case PresetType::LAVALAMP: {
     static uint8_t lavaPos = 0;
+    EVERY_N_MILLISECONDS(50) { ++lavaPos; }
     for (int i = 0; i < cfg::NUM_LEDS; ++i) {
       leds[i] = CHSV((lavaPos + i * 10) % 255, 200, 255);
     }
-    ++lavaPos;
   } break;
   }
+
   FastLED.show();
 }
 
@@ -303,8 +309,5 @@ void loop() {
   ws.loop();
   ArduinoOTA.handle();
 
-  if (millis() - lastAnim > 50) {
-    applyPreset();
-    lastAnim = millis();
-  }
+  applyPreset();
 }


### PR DESCRIPTION
## Summary
- use `EVERY_N_MILLISECONDS` timers inside `applyPreset()` for dynamic effects
- call `applyPreset()` each loop instead of relying on `lastAnim`

## Testing
- `./setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843e72d21a08332a94aaecbd55e85cd