### PR TITLE
Enhance docs for presets and WebSocket commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,21 @@ Available commands:
 * `prev` &mdash; switch to the previous preset.
 * `set:<n>` &mdash; activate the preset with index `<n>` (zero based), e.g. `set:0`.
 
+### WebSocket Commands
+
+Below are example messages for each command when using [`wscat`](https://github.com/websockets/wscat):
+
+```bash
+# Advance to the next preset
+wscat -c ws://<device_ip>:81/ -x next
+
+# Go back to the previous preset
+wscat -c ws://<device_ip>:81/ -x prev
+
+# Explicitly select preset number 2
+wscat -c ws://<device_ip>:81/ -x set:2
+```
+
 ### Building
 Run `setup.sh` once to install PlatformIO and build the firmware:
 

--- a/src/goggles.ino
+++ b/src/goggles.ino
@@ -25,12 +25,12 @@ const char *PASSWORD = WIFI_PASSWORD;
 /**
  * Types of LED animations.
  *
- * - `STATIC`     Solid color chosen per preset
- * - `RAINBOW`    Continuously cycling rainbow
- * - `POLICE_NL`  Blue and white pattern similar to Dutch police lights
- * - `POLICE_USA` Red, white and blue pattern similar to US police lights
- * - `STROBE`     Fast white flash on and off
- * - `LAVALAMP`   Slowly moving color gradient
+ * - `STATIC` &mdash; Solid color chosen per preset.
+ * - `RAINBOW` &mdash; Continuously cycling rainbow.
+ * - `POLICE_NL` &mdash; Blue and white pattern similar to Dutch police lights.
+ * - `POLICE_USA` &mdash; Red, white and blue pattern similar to US police lights.
+ * - `STROBE` &mdash; Fast white flash on and off.
+ * - `LAVALAMP` &mdash; Slowly moving color gradient.
  */
 enum class PresetType {
   STATIC,


### PR DESCRIPTION
## Summary
- clarify each `PresetType` with a comment block above the enum
- add a README section with WebSocket command examples

## Testing
- `./setup.sh` *(fails: include/secrets.h not found)*
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_6843e737d26c833298aeb569fe82550a