### PR TITLE
Add tests and CI workflow

### DIFF
--- a/.github/workflows/pio.yml
+++ b/.github/workflows/pio.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install PlatformIO
+        run: pip install platformio
+      - name: Prepare secrets
+        run: cp include/secrets_example.h include/secrets.h
+      - name: Run tests
+        run: pio test -e native
+      - name: Build firmware
+        run: pio run -e esp32

--- a/include/secrets.h
+++ b/include/secrets.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#define WIFI_SSID "changeme"
+#define WIFI_PASSWORD "changeme"

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,0 +1,4 @@
+#pragma once
+#include <stdint.h>
+
+bool parseHexColor(const char *hex, uint32_t &value);

--- a/platformio.ini
+++ b/platformio.ini
@@ -7,3 +7,11 @@ lib_deps =
     fastled
     links2004/WebSockets
 
+[env:native]
+platform = native
+build_flags = -std=c++11
+lib_deps =
+    unity
+test_build_src = true
+build_src_filter = +<utils.cpp>
+

--- a/src/goggles.ino
+++ b/src/goggles.ino
@@ -3,6 +3,7 @@
  * Provides WiFi control and OTA updates
  */
 #include "secrets.h"
+#include "utils.h"
 #include <Arduino.h>
 #include <ArduinoOTA.h>
 #include <ESPmDNS.h>
@@ -201,18 +202,15 @@ void handleAdd() {
     return;
   }
 
-  colorStr = colorStr.substring(1);
-  for (size_t i = 0; i < colorStr.length(); ++i) {
-    if (!isxdigit(static_cast<unsigned char>(colorStr[i]))) {
-      server.send(400, "text/html",
-                  "<html><body><p>Color contains invalid hex characters.</p><a href='/' >Back</a></body></html>");
-      return;
-    }
+  uint32_t colorVal;
+  if (!parseHexColor(colorStr.c_str() + 1, colorVal)) {
+    server.send(400, "text/html",
+                "<html><body><p>Color contains invalid hex characters.</p><a href='/' >Back</a></body></html>");
+    return;
   }
 
-  long val = strtol(colorStr.c_str(), nullptr, 16);
   presets.push_back({name, PresetType::STATIC,
-                     CRGB((val >> 16) & 0xFF, (val >> 8) & 0xFF, val & 0xFF)});
+                     CRGB((colorVal >> 16) & 0xFF, (colorVal >> 8) & 0xFF, colorVal & 0xFF)});
   currentPreset = presets.size() - 1;
   applyPreset();
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,15 @@
+#include "utils.h"
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+
+bool parseHexColor(const char *hex, uint32_t &value) {
+    if (!hex || strlen(hex) != 6)
+        return false;
+    for (size_t i = 0; i < 6; ++i) {
+        if (!isxdigit(static_cast<unsigned char>(hex[i])))
+            return false;
+    }
+    value = strtoul(hex, nullptr, 16);
+    return true;
+}

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -1,0 +1,27 @@
+#include <unity.h>
+#include "utils.h"
+
+void test_valid_color() {
+    uint32_t val;
+    TEST_ASSERT_TRUE(parseHexColor("ff00ff", val));
+    TEST_ASSERT_EQUAL_HEX32(0xff00ff, val);
+}
+
+void test_invalid_length() {
+    uint32_t val;
+    TEST_ASSERT_FALSE(parseHexColor("fff", val));
+}
+
+void test_invalid_chars() {
+    uint32_t val;
+    TEST_ASSERT_FALSE(parseHexColor("gg0000", val));
+}
+
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+    RUN_TEST(test_valid_color);
+    RUN_TEST(test_invalid_length);
+    RUN_TEST(test_invalid_chars);
+    return UNITY_END();
+}
+


### PR DESCRIPTION
## Summary
- add parseHexColor utility and use in `handleAdd`
- create unit tests for parsing functions
- provide sample secrets for builds
- add PlatformIO `native` environment for tests
- run tests and firmware build in GitHub Actions

## Testing
- `pio test -e native`
- `pio run -e esp32`

------
https://chatgpt.com/codex/tasks/task_e_6843e735837c8332a9ec2d404a96b839