### PR TITLE
Add Off preset as startup state

### DIFF
--- a/src/goggles.ino
+++ b/src/goggles.ino
@@ -170,7 +170,7 @@ void saveCustomPresets() {
   File f = SPIFFS.open("/presets.txt", "w");
   if (!f)
     return;
-  for (size_t i = DEFAULT_PRESET_COUNT; i < presets.size(); ++i) {
+  for (size_t i = DEFAULT_PRESET_COUNT; i + 1 < presets.size(); ++i) {
     char buf[64];
     sprintf(buf, "%s,%d,%02x%02x%02x\n", presets[i].name.c_str(),
             static_cast<int>(presets[i].type), presets[i].color.r,
@@ -337,9 +337,11 @@ void handleAdd() {
     return;
   }
 
-  presets.push_back({name, PresetType::STATIC,
-                     CRGB((colorVal >> 16) & 0xFF, (colorVal >> 8) & 0xFF, colorVal & 0xFF)});
-  currentPreset = presets.size() - 1;
+  presets.insert(presets.end() - 1,
+                 {name, PresetType::STATIC,
+                  CRGB((colorVal >> 16) & 0xFF, (colorVal >> 8) & 0xFF,
+                       colorVal & 0xFF)});
+  currentPreset = presets.size() - 2;
   saveCustomPresets();
   applyPreset();
 
@@ -471,6 +473,8 @@ void setup() {
   SPIFFS.begin(true);
   loadDefaultPresets();
   loadCustomPresets();
+  presets.push_back({"Off", PresetType::STATIC, CRGB::Black});
+  currentPreset = presets.size() - 1;
 
   connectWiFi();
   if (MDNS.begin("JohannesBril")) {


### PR DESCRIPTION
## Summary
- keep custom presets out of last slot so "Off" preset always stays last
- insert new presets before the final "Off" entry
- start with goggles turned off by appending an "Off" preset during setup

## Testing
- `pio test -e native`

------
https://chatgpt.com/codex/tasks/task_e_6843f25330c8833280e0eddce7fb74a6