### PR TITLE
Remove secrets from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,3 @@
 # Local WiFi credentials
 include/secrets.h
 
-
-
-

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ wscat -c ws://<device_ip>:81/ -x set:2
 ```
 
 ### Building
+Before building, copy `include/secrets_example.h` to `include/secrets.h` and set
+your WiFi credentials.
 Run `setup.sh` once to install PlatformIO and build the firmware:
 
 ```bash

--- a/include/secrets.h
+++ b/include/secrets.h
@@ -1,4 +1,0 @@
-#pragma once
-
-#define WIFI_SSID "changeme"
-#define WIFI_PASSWORD "changeme"


### PR DESCRIPTION
## Summary
- remove `include/secrets.h` from version control
- keep `include/secrets.h` ignored
- note in the README to create `include/secrets.h` before building

## Testing
- `pio test -e native`

------
https://chatgpt.com/codex/tasks/task_e_6843f7d9beb083328f8b64d02ade5894