### PR TITLE
Add cpplint for Arduino sources

### DIFF
--- a/.github/workflows/pio.yml
+++ b/.github/workflows/pio.yml
@@ -12,9 +12,12 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install PlatformIO
-        run: pip install platformio
+        run: pip install platformio cpplint
       - name: Prepare secrets
         run: cp include/secrets_example.h include/secrets.h
+      - name: Lint sources
+        run: |
+          cpplint --recursive src include test || true
       - name: Run tests
         run: pio test -e native
       - name: Build firmware

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,1 @@
+extensions=cpp,h,ino

--- a/README.md
+++ b/README.md
@@ -88,3 +88,11 @@ While running, check the serial output at `115200` baud:
 ```bash
 pio device monitor
 ```
+
+### Linting
+Arduino sources are checked with [cpplint](https://github.com/cpplint/cpplint).
+Run the linter after making changes:
+
+```bash
+cpplint --recursive src include test
+```


### PR DESCRIPTION
## Summary
- configure cpplint to also handle `.ino` files
- document how to lint the firmware
- run cpplint in CI to warn about issues

## Testing
- `pio test -e native`

------
https://chatgpt.com/codex/tasks/task_e_6843f7ddf5648332846a030ee0b3e672