### PR TITLE
Fix broken preset array

### DIFF
--- a/include/unity_config.h
+++ b/include/unity_config.h
@@ -1,0 +1,3 @@
+#ifndef UNITY_CONFIG_H
+#define UNITY_CONFIG_H
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,3 +1,6 @@
+[platformio]
+default_envs = esp32
+
 [env:esp32]
 platform = espressif32
 board = esp32dev
@@ -9,7 +12,9 @@ lib_deps =
 
 [env:native]
 platform = native
-build_flags = -std=c++11
+build_flags =
+    -std=c++11
+    -Iinclude
 lib_deps =
     unity
 test_build_src = true

--- a/src/goggles.ino
+++ b/src/goggles.ino
@@ -64,15 +64,17 @@ struct PresetData {
   CRGB color;
 };
 
-const {"White", PresetType::STATIC, CRGB::White},
-                            {"Rainbow", PresetType::RAINBOW, CRGB::Black},
-                            {"Police NL", PresetType::POLICE_NL, CRGB::Black},
-                            {"Police USA", PresetType::POLICE_USA, CRGB::Black},
-                            {"Strobe", PresetType::STROBE, CRGB::Black},
-                            {"Lavalamp", PresetType::LAVALAMP, CRGB::Black},
-                            {"Fire", PresetType::FIRE, CRGB::Black},
-                            {"Candle", PresetType::CANDLE, CRGB::Black},
-                            {"Party", PresetType::PARTY, CRGB::Black}};
+const PROGMEM PresetData defaultPresets[] = {
+    {"White", PresetType::STATIC, CRGB::White},
+    {"Rainbow", PresetType::RAINBOW, CRGB::Black},
+    {"Police NL", PresetType::POLICE_NL, CRGB::Black},
+    {"Police USA", PresetType::POLICE_USA, CRGB::Black},
+    {"Strobe", PresetType::STROBE, CRGB::Black},
+    {"Lavalamp", PresetType::LAVALAMP, CRGB::Black},
+    {"Fire", PresetType::FIRE, CRGB::Black},
+    {"Candle", PresetType::CANDLE, CRGB::Black},
+    {"Party", PresetType::PARTY, CRGB::Black}
+};
 std::vector<Preset> presets;
 const size_t DEFAULT_PRESET_COUNT = sizeof(defaultPresets) / sizeof(defaultPresets[0]);
 


### PR DESCRIPTION
## Summary
- correct preset array declaration in `goggles.ino`
- add minimal `unity_config.h`
- ensure PlatformIO only builds `esp32` environment and provide include path for tests

## Testing
- `./setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843f763965483329d7704d2523c47a9