### PR TITLE
Fix default preset array definition

### DIFF
--- a/src/goggles.ino
+++ b/src/goggles.ino
@@ -64,12 +64,7 @@ struct PresetData {
   CRGB color;
 };
 
-
-const PROGMEM PresetData defaultPresets[] = {
-
-
-
-
+const PresetData defaultPresets[] PROGMEM = {
     {"White", PresetType::STATIC, CRGB::White},
     {"Rainbow", PresetType::RAINBOW, CRGB::Black},
     {"Police NL", PresetType::POLICE_NL, CRGB::Black},
@@ -78,11 +73,7 @@ const PROGMEM PresetData defaultPresets[] = {
     {"Lavalamp", PresetType::LAVALAMP, CRGB::Black},
     {"Fire", PresetType::FIRE, CRGB::Black},
     {"Candle", PresetType::CANDLE, CRGB::Black},
-
-    {"Party", PresetType::PARTY, CRGB::Black}
-
-
-
+    {"Party", PresetType::PARTY, CRGB::Black},
 };
 std::vector<Preset> presets;
 const size_t DEFAULT_PRESET_COUNT = sizeof(defaultPresets) / sizeof(defaultPresets[0]);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,7 +1,7 @@
 // Copyright 2025 Bootj05
 //
 // Licensed under the MIT License.
-#include "include/utils.h"
+#include "utils.h"
 #include <ctype.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
## Summary
- store default preset list in program memory
- fix utils include path

## Testing
- `./setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843fd64b35c83329f74a642b2f63b06