### PR TITLE
Fix default presets array and tests

### DIFF
--- a/src/goggles.ino
+++ b/src/goggles.ino
@@ -64,7 +64,7 @@ struct PresetData {
   CRGB color;
 };
 
-const PresetData defaultPresets[] PROGMEM = {
+constexpr PresetData defaultPresets[] PROGMEM = {
     {"White", PresetType::STATIC, CRGB::White},
     {"Rainbow", PresetType::RAINBOW, CRGB::Black},
     {"Police NL", PresetType::POLICE_NL, CRGB::Black},

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -1,6 +1,6 @@
 #include <unity.h>
 // Copyright 2025 Bootj05
-#include "include/utils.h"
+#include "utils.h"
 
 void test_valid_color() {
     uint32_t val;


### PR DESCRIPTION
## Summary
- store the `defaultPresets` array in PROGMEM as constexpr
- fix test header path

## Testing
- `./setup.sh`
- `pio test -e native`


------
https://chatgpt.com/codex/tasks/task_e_6843ffe42fb48332b359709c59f5a4eb