### PR TITLE
Add secrets creation prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Pair of specs with magnifier glass upgraded with 13 LEDs.
 ## Firmware
 
 Firmware lives in `src` and is built with [PlatformIO](https://platformio.org/).
-Copy `include/secrets_example.h` to `include/secrets.h` and add your WiFi
-credentials as `WIFI_SSID` and `WIFI_PASSWORD`.
+You can copy `include/secrets_example.h` to `include/secrets.h` and add your
+WiFi credentials manually, or simply run one of the helper scripts which will
+prompt for the SSID and password if the file is missing.
 To protect the web interface and WebSocket API you can set `USE_AUTH` to `1`
 and choose an `AUTH_TOKEN` in `secrets.h`. When enabled, the `/add` endpoint
 expects a `token` parameter and WebSocket commands must be prefixed with
@@ -58,9 +59,10 @@ wscat -c ws://<device_ip>:81/ -x set:2
 ```
 
 ### Building
-Before building, copy `include/secrets_example.h` to `include/secrets.h` and set
-your WiFi credentials.
-Run `setup.sh` once to install PlatformIO and build the firmware:
+Run `setup.sh` once to install PlatformIO and build the firmware. If
+`include/secrets.h` is missing the script will offer to create it and ask for
+your WiFi SSID and password. It also offers to create or use a Python virtual
+environment before installing dependencies:
 
 ```bash
 ./setup.sh
@@ -79,7 +81,9 @@ pio run --target upload
 ```
 
 Alternatively use `install.sh` to build the project, optionally export the
-compiled binary and flash a connected ESP32 automatically:
+compiled binary and flash a connected ESP32 automatically. If
+`include/secrets.h` is missing it will prompt for your WiFi details just like
+`setup.sh`. Both scripts also allow using a virtual environment:
 
 ```bash
 ./install.sh

--- a/install.sh
+++ b/install.sh
@@ -2,23 +2,52 @@
 # Install and flash script for ESP32
 set -e
 
+# Offer a Python virtual environment
+read -p "Use a Python virtual environment? [y/N] " use_venv
+if [[ $use_venv =~ ^[Yy]$ ]]; then
+    read -p "Path to virtual environment (default .venv): " venv_path
+    venv_path=${venv_path:-.venv}
+    if [ ! -d "$venv_path" ]; then
+        echo "Creating virtual environment at $venv_path..."
+        python3 -m venv "$venv_path"
+    fi
+    # shellcheck disable=SC1090
+    source "$venv_path/bin/activate"
+fi
+
 # Ensure PlatformIO is installed
 if ! command -v pio >/dev/null 2>&1; then
     echo "Installing PlatformIO CLI..."
-    if ! python3 -m pip install --user -U platformio; then
+    pip_opts=""
+    if [ -z "$VIRTUAL_ENV" ]; then
+        pip_opts="--user"
+    fi
+    if ! python3 -m pip install $pip_opts -U platformio; then
         echo "Failed to install PlatformIO." >&2
         echo "Please check your network connection or install it manually:" >&2
         echo "https://docs.platformio.org/en/latest/core/installation.html" >&2
         exit 1
     fi
-    export PATH="$PATH:$(python3 -m site --user-base)/bin"
+    if [ -z "$VIRTUAL_ENV" ]; then
+        export PATH="$PATH:$(python3 -m site --user-base)/bin"
+    fi
 fi
 
 # Verify secrets
 if [ ! -f include/secrets.h ]; then
-    echo "include/secrets.h not found." >&2
-    echo "Copy include/secrets_example.h to include/secrets.h and set your WiFi credentials." >&2
-    exit 1
+    echo "include/secrets.h not found."
+    read -p "Create it now? [y/N] " create_secrets
+    if [[ $create_secrets =~ ^[Yy]$ ]]; then
+        cp include/secrets_example.h include/secrets.h
+        read -p "WiFi SSID: " wifi_ssid
+        read -p "WiFi password: " wifi_pass
+        sed -i "s|#define WIFI_SSID .*|#define WIFI_SSID \"${wifi_ssid}\"|" include/secrets.h
+        sed -i "s|#define WIFI_PASSWORD .*|#define WIFI_PASSWORD \"${wifi_pass}\"|" include/secrets.h
+        echo "Created include/secrets.h"
+    else
+        echo "Please create include/secrets.h before proceeding." >&2
+        exit 1
+    fi
 fi
 
 # Build firmware for esp32 environment

--- a/setup.sh
+++ b/setup.sh
@@ -2,23 +2,52 @@
 # Set up PlatformIO and build the firmware
 set -e
 
+# Offer a Python virtual environment
+read -p "Use a Python virtual environment? [y/N] " use_venv
+if [[ $use_venv =~ ^[Yy]$ ]]; then
+    read -p "Path to virtual environment (default .venv): " venv_path
+    venv_path=${venv_path:-.venv}
+    if [ ! -d "$venv_path" ]; then
+        echo "Creating virtual environment at $venv_path..."
+        python3 -m venv "$venv_path"
+    fi
+    # shellcheck disable=SC1090
+    source "$venv_path/bin/activate"
+fi
+
 # Detect platformio
 if ! command -v pio >/dev/null 2>&1; then
     echo "Installing PlatformIO CLI..."
-    if ! python3 -m pip install --user -U platformio; then
+    pip_opts=""
+    if [ -z "$VIRTUAL_ENV" ]; then
+        pip_opts="--user"
+    fi
+    if ! python3 -m pip install $pip_opts -U platformio; then
         echo "Failed to install PlatformIO." >&2
         echo "Please check your network connection or install it manually:" >&2
         echo "https://docs.platformio.org/en/latest/core/installation.html" >&2
         exit 1
     fi
-    export PATH="$PATH:$(python3 -m site --user-base)/bin"
+    if [ -z "$VIRTUAL_ENV" ]; then
+        export PATH="$PATH:$(python3 -m site --user-base)/bin"
+    fi
 fi
 
 # Verify secrets.h exists before building
 if [ ! -f include/secrets.h ]; then
-    echo "include/secrets.h not found." >&2
-    echo "Copy include/secrets_example.h to include/secrets.h and set your WiFi credentials." >&2
-    exit 1
+    echo "include/secrets.h not found."
+    read -p "Create it now? [y/N] " create_secrets
+    if [[ $create_secrets =~ ^[Yy]$ ]]; then
+        cp include/secrets_example.h include/secrets.h
+        read -p "WiFi SSID: " wifi_ssid
+        read -p "WiFi password: " wifi_pass
+        sed -i "s|#define WIFI_SSID .*|#define WIFI_SSID \"${wifi_ssid}\"|" include/secrets.h
+        sed -i "s|#define WIFI_PASSWORD .*|#define WIFI_PASSWORD \"${wifi_pass}\"|" include/secrets.h
+        echo "Created include/secrets.h"
+    else
+        echo "Please create include/secrets.h before proceeding." >&2
+        exit 1
+    fi
 fi
 
 # Build firmware


### PR DESCRIPTION
## Summary
- prompt for WiFi credentials if `include/secrets.h` is missing
- keep optional virtualenv creation in setup and install scripts
- document secrets prompt in the README

## Testing
- `cpplint --recursive src include test` *(fails: header guards)*
- `pip install platformio`
- `pio test -e native`


------
https://chatgpt.com/codex/tasks/task_e_684400bec8c08332b00cf956551838d6