### PR TITLE
Add python3 prerequisite check

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -5,6 +5,10 @@ set -e
 # Detect platformio
 if ! command -v pio >/dev/null 2>&1; then
     echo "Installing PlatformIO CLI..."
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "python3 is required but not found. Please install Python 3 and pip." >&2
+        exit 1
+    fi
     if ! python3 -m pip install --user -U platformio; then
         echo "Failed to install PlatformIO." >&2
         echo "Please check your network connection or install it manually:" >&2


### PR DESCRIPTION
## Summary
- detect absence of Python 3 before installing PlatformIO

## Testing
- `cpplint --recursive src include test` *(fails: Total errors found: 5)*

------
https://chatgpt.com/codex/tasks/task_e_684404b4a4ac833296075e3c164dbf7b