### PR TITLE
Add prerequisites section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Pair of specs with magnifier glass upgraded with 13 LEDs.
 
+## Prerequisites
+
+`python3` and `pip` must be installed before running `setup.sh` or
+`install.sh`. These scripts will install PlatformIO automatically. You
+can use a Python virtual environment if preferred.
+
 ## Firmware
 
 Firmware lives in `src` and is built with [PlatformIO](https://platformio.org/).


### PR DESCRIPTION
## Summary
- document required Python tools before running setup scripts

## Testing
- `cpplint --recursive src include test` *(fails: build/header_guard etc.)*
- `./setup.sh` *(fails: include/secrets.h not found)*
- `pio test` *(fails: undefined reference to `setup()`)*

------
https://chatgpt.com/codex/tasks/task_e_684404b3874c8332b9beb02e2a3b85e1