### PR TITLE
Add Python 3 check to install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,12 @@
 # Install and flash script for ESP32
 set -e
 
+# Ensure Python 3 is available
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "Python 3 is required but was not found. Please install Python 3 and try again." >&2
+    exit 1
+fi
+
 # Ensure PlatformIO is installed
 if ! command -v pio >/dev/null 2>&1; then
     echo "Installing PlatformIO CLI..."


### PR DESCRIPTION
## Summary
- ensure `install.sh` checks for Python 3 before running

## Testing
- `pio test -e native`


------
https://chatgpt.com/codex/tasks/task_e_684404b5b8208332ba1dcd9a71cc9a93