### PR TITLE
Handle button pins without internal pull‑ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ expects a `token` parameter and WebSocket commands must be prefixed with
 - Custom mDNS hostname
 
 ### Hardware
-The previous and next buttons are wired as active-low and rely on the microcontroller's internal pull-up resistors.
+The previous and next buttons are wired as active-low. Pins 34--39 on the
+ESP32 can't use internal pull-ups, so if you connect a button to one of those
+pins (e.g. GPIO35) make sure an external pull-up resistor is present.
 
 ### WebSocket API
 The firmware also runs a WebSocket server on port `81`. Send plain text commands

--- a/src/goggles.ino
+++ b/src/goggles.ino
@@ -536,8 +536,12 @@ void wsEvent(uint8_t num, WStype_t type, uint8_t *payload, size_t len) {
 void setup() {
   Serial.begin(115200);
   pinMode(cfg::BTN_PREV, INPUT_PULLUP);
-  // Buttons use internal pull-ups and are thus active-low
-  pinMode(cfg::BTN_NEXT, INPUT_PULLUP);
+  // Buttons are active-low. Pins 34-39 do not support internal pull-ups,
+  // so fall back to plain INPUT when necessary.
+  if (cfg::BTN_NEXT >= 34)
+    pinMode(cfg::BTN_NEXT, INPUT);
+  else
+    pinMode(cfg::BTN_NEXT, INPUT_PULLUP);
   FastLED.addLeds<WS2812, cfg::LED_PIN, GRB>(leds, cfg::NUM_LEDS);
   FastLED.setBrightness(brightness);
 


### PR DESCRIPTION
## Summary
- avoid INPUT_PULLUP on pins that can't use it
- document that GPIO34+ needs an external pull-up resistor

## Testing
- `cpplint --recursive src include test`
- `pio test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844069d50e48332a812236736827503