### PR TITLE
Fix sed compatibility for macOS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,20 @@
 # Install and flash script for ESP32
 set -e
 
+# Determine sed command and in-place arguments
+SED="sed"
+if command -v gsed >/dev/null 2>&1; then
+    SED="gsed"
+fi
+if "$SED" --version 2>/dev/null | grep -q "GNU"; then
+    SED_INPLACE_ARGS=(-i)
+else
+    SED_INPLACE_ARGS=(-i '')
+fi
+sed_inplace() {
+    "$SED" "${SED_INPLACE_ARGS[@]}" "$@"
+}
+
 
 # Offer a Python virtual environment
 read -p "Use a Python virtual environment? [y/N] " use_venv
@@ -42,8 +56,8 @@ if [ ! -f include/secrets.h ]; then
         cp include/secrets_example.h include/secrets.h
         read -p "WiFi SSID: " wifi_ssid
         read -p "WiFi password: " wifi_pass
-        sed -i "s|#define WIFI_SSID .*|#define WIFI_SSID \"${wifi_ssid}\"|" include/secrets.h
-        sed -i "s|#define WIFI_PASSWORD .*|#define WIFI_PASSWORD \"${wifi_pass}\"|" include/secrets.h
+        sed_inplace "s|#define WIFI_SSID .*|#define WIFI_SSID \"${wifi_ssid}\"|" include/secrets.h
+        sed_inplace "s|#define WIFI_PASSWORD .*|#define WIFI_PASSWORD \"${wifi_pass}\"|" include/secrets.h
         echo "Created include/secrets.h"
     else
         echo "Please create include/secrets.h before proceeding." >&2

--- a/setup.sh
+++ b/setup.sh
@@ -2,6 +2,20 @@
 # Set up PlatformIO and build the firmware
 set -e
 
+# Determine sed command and in-place arguments
+SED="sed"
+if command -v gsed >/dev/null 2>&1; then
+    SED="gsed"
+fi
+if "$SED" --version 2>/dev/null | grep -q "GNU"; then
+    SED_INPLACE_ARGS=(-i)
+else
+    SED_INPLACE_ARGS=(-i '')
+fi
+sed_inplace() {
+    "$SED" "${SED_INPLACE_ARGS[@]}" "$@"
+}
+
 # Offer a Python virtual environment
 read -p "Use a Python virtual environment? [y/N] " use_venv
 if [[ $use_venv =~ ^[Yy]$ ]]; then
@@ -41,8 +55,8 @@ if [ ! -f include/secrets.h ]; then
         cp include/secrets_example.h include/secrets.h
         read -p "WiFi SSID: " wifi_ssid
         read -p "WiFi password: " wifi_pass
-        sed -i "s|#define WIFI_SSID .*|#define WIFI_SSID \"${wifi_ssid}\"|" include/secrets.h
-        sed -i "s|#define WIFI_PASSWORD .*|#define WIFI_PASSWORD \"${wifi_pass}\"|" include/secrets.h
+        sed_inplace "s|#define WIFI_SSID .*|#define WIFI_SSID \"${wifi_ssid}\"|" include/secrets.h
+        sed_inplace "s|#define WIFI_PASSWORD .*|#define WIFI_PASSWORD \"${wifi_pass}\"|" include/secrets.h
         echo "Created include/secrets.h"
     else
         echo "Please create include/secrets.h before proceeding." >&2


### PR DESCRIPTION
## Summary
- detect GNU sed in `setup.sh` and `install.sh`
- use `sed -i ''` on macOS or fallback sed

## Testing
- `cpplint --recursive src include test` *(fails: header guard style issues)*
- `pio test -e native`

------
https://chatgpt.com/codex/tasks/task_e_68440d9a78f48332a9b4dd0ab386279e