### PR TITLE
Keep installer window open on exit

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,9 @@
 # Install and flash script for ESP32
 set -e
 
+# Always pause before exiting so the terminal stays open on failure or success
+trap 'echo; read -n 1 -r -p "Press any key to exit..."' EXIT
+
 # Determine sed command and in-place arguments
 SED="sed"
 if command -v gsed >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- keep the install.sh window open after the script exits

## Testing
- `cpplint --recursive src include test`
- `pio test -e native`

------
https://chatgpt.com/codex/tasks/task_e_68441143f9608332a921d8a373b86710