### PR TITLE
Fix macOS sed usage

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,18 @@
 # Install and flash script for ESP32
 set -e
 
+# Choose sed command (use gsed if available)
+SED=sed
+if command -v gsed >/dev/null 2>&1; then
+    SED=gsed
+fi
+if $SED --version >/dev/null 2>&1; then
+    SED_INPLACE=("$SED" -i)
+else
+    # macOS/BSD sed requires a suffix for -i
+    SED_INPLACE=("$SED" -i '')
+fi
+
 
 # Offer a Python virtual environment
 read -p "Use a Python virtual environment? [y/N] " use_venv
@@ -42,8 +54,8 @@ if [ ! -f include/secrets.h ]; then
         cp include/secrets_example.h include/secrets.h
         read -p "WiFi SSID: " wifi_ssid
         read -p "WiFi password: " wifi_pass
-        sed -i "s|#define WIFI_SSID .*|#define WIFI_SSID \"${wifi_ssid}\"|" include/secrets.h
-        sed -i "s|#define WIFI_PASSWORD .*|#define WIFI_PASSWORD \"${wifi_pass}\"|" include/secrets.h
+        "${SED_INPLACE[@]}" "s|#define WIFI_SSID .*|#define WIFI_SSID \"${wifi_ssid}\"|" include/secrets.h
+        "${SED_INPLACE[@]}" "s|#define WIFI_PASSWORD .*|#define WIFI_PASSWORD \"${wifi_pass}\"|" include/secrets.h
         echo "Created include/secrets.h"
     else
         echo "Please create include/secrets.h before proceeding." >&2

--- a/setup.sh
+++ b/setup.sh
@@ -2,6 +2,18 @@
 # Set up PlatformIO and build the firmware
 set -e
 
+# Choose sed command (use gsed if available)
+SED=sed
+if command -v gsed >/dev/null 2>&1; then
+    SED=gsed
+fi
+if $SED --version >/dev/null 2>&1; then
+    SED_INPLACE=("$SED" -i)
+else
+    # macOS/BSD sed requires a suffix for -i
+    SED_INPLACE=("$SED" -i '')
+fi
+
 # Offer a Python virtual environment
 read -p "Use a Python virtual environment? [y/N] " use_venv
 if [[ $use_venv =~ ^[Yy]$ ]]; then
@@ -41,8 +53,8 @@ if [ ! -f include/secrets.h ]; then
         cp include/secrets_example.h include/secrets.h
         read -p "WiFi SSID: " wifi_ssid
         read -p "WiFi password: " wifi_pass
-        sed -i "s|#define WIFI_SSID .*|#define WIFI_SSID \"${wifi_ssid}\"|" include/secrets.h
-        sed -i "s|#define WIFI_PASSWORD .*|#define WIFI_PASSWORD \"${wifi_pass}\"|" include/secrets.h
+        "${SED_INPLACE[@]}" "s|#define WIFI_SSID .*|#define WIFI_SSID \"${wifi_ssid}\"|" include/secrets.h
+        "${SED_INPLACE[@]}" "s|#define WIFI_PASSWORD .*|#define WIFI_PASSWORD \"${wifi_pass}\"|" include/secrets.h
         echo "Created include/secrets.h"
     else
         echo "Please create include/secrets.h before proceeding." >&2


### PR DESCRIPTION
## Summary
- add `SED` detection in setup and install scripts
- use portable `sed -i` invocation

## Testing
- `cpplint --recursive src include test` *(fails: header guard and include warnings)*
- `pio test -e native` *(fails: `pio: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68440db6eae08332a0a9098d5d468c41