### PR TITLE
Update FastLED dependency

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -7,7 +7,7 @@ board = esp32dev
 framework = arduino
 monitor_speed = 115200
 lib_deps =
-    fastled
+    fastled/FastLED@3.9.20
     links2004/WebSockets
 
 [env:native]


### PR DESCRIPTION
## Summary
- use explicit version for the FastLED library in `platformio.ini`

## Testing
- `pio run -e esp32` *(fails: missing `secrets.h`)*

------
https://chatgpt.com/codex/tasks/task_e_684419bfde3c8332aae4997ad2eaf73d