### PR TITLE
Add pinned FastLED version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -76,6 +76,7 @@ if [ ! -f include/secrets.h ]; then
 fi
 
 # Build firmware for esp32 environment
+pio lib -g install fastled/FastLED@3.9.20
 pio run -e esp32
 
 BIN_PATH=.pio/build/esp32/firmware.bin

--- a/platformio.ini
+++ b/platformio.ini
@@ -7,7 +7,7 @@ board = esp32dev
 framework = arduino
 monitor_speed = 115200
 lib_deps =
-    fastled
+    fastled/FastLED@3.9.20
     links2004/WebSockets
 
 [env:native]

--- a/setup.sh
+++ b/setup.sh
@@ -72,4 +72,5 @@ if [ ! -f include/secrets.h ]; then
 fi
 
 # Build firmware
+pio lib -g install fastled/FastLED@3.9.20
 pio run


### PR DESCRIPTION
## Summary
- pin FastLED version in `platformio.ini`
- install the exact FastLED version before building in `install.sh` and `setup.sh`

## Testing
- `cpplint --recursive src include test`
- `pio test -e native`
- `yes "" | ./install.sh`

------
https://chatgpt.com/codex/tasks/task_e_684419c318b4833291cc4d40e1b1a140