### PR TITLE
Enable OTA updates via WiFi

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,22 @@ Upload to the device with:
 pio run --target upload
 ```
 
+### OTA updates
+Once the firmware has been flashed at least once you can upload new
+versions over WiFi. The `esp32-ota` PlatformIO environment is configured
+for OTA using the default mDNS host `JohannesBril.local`.
+
+```bash
+pio run -e esp32-ota --target upload
+```
+
+If you changed the hostname or need to use an IP address pass it as the
+`--upload-port` value:
+
+```bash
+pio run -e esp32-ota --target upload --upload-port <ip_or_hostname>
+```
+
 Alternatively use `install.sh` to build the project, optionally export the
 compiled binary and flash a connected ESP32 automatically. If
 `include/secrets.h` is missing it will prompt for your WiFi details just like

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,6 +10,17 @@ lib_deps =
     fastled
     links2004/WebSockets
 
+[env:esp32-ota]
+platform = espressif32
+board = esp32dev
+framework = arduino
+monitor_speed = 115200
+upload_protocol = espota
+upload_port = johannesbril.local
+lib_deps =
+    fastled
+    links2004/WebSockets
+
 [env:native]
 platform = native
 build_flags = 


### PR DESCRIPTION
## Summary
- document OTA uploads
- add PlatformIO env for OTA uploading

## Testing
- `cpplint --recursive src include test`
- `pio run`
- `pio test -e native`


------
https://chatgpt.com/codex/tasks/task_e_68441b0c0f008332a70e2bf1e82be2c5