### PR TITLE
Fix sed invocation on macOS

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -7,13 +7,25 @@ SED="sed"
 if command -v gsed >/dev/null 2>&1; then
     SED="gsed"
 fi
+
+HAS_GNU_SED=false
 if "$SED" --version 2>/dev/null | grep -q "GNU"; then
-    SED_INPLACE_ARGS=(-i)
-else
-    SED_INPLACE_ARGS=(-i '')
+    HAS_GNU_SED=true
 fi
+
 sed_inplace() {
-    "$SED" "${SED_INPLACE_ARGS[@]}" "$@"
+    local expr="$1"
+    local file="$2"
+    if $HAS_GNU_SED; then
+        "$SED" -i -e "$expr" "$file"
+    elif [[ "$(uname)" == "Darwin" ]]; then
+        "$SED" -i '' -e "$expr" "$file"
+    else
+        local tmp
+        tmp=$(mktemp)
+        "$SED" -e "$expr" "$file" > "$tmp"
+        mv "$tmp" "$file"
+    fi
 }
 
 # Escape special characters for sed replacement


### PR DESCRIPTION
## Summary
- detect GNU `sed` vs BSD `sed`
- update `setup.sh` and `install.sh` to call `sed` with the right in‑place flags

## Testing
- `bash -n setup.sh`
- `bash -n install.sh`
- `cpplint --recursive src include test` *(fails: header guard and include style issues)*

------
https://chatgpt.com/codex/tasks/task_e_68441d52bc64833287f5111cb8a509c8