### PR TITLE
Add brightness slider

### DIFF
--- a/src/goggles.ino
+++ b/src/goggles.ino
@@ -354,6 +354,12 @@ const char HTML_PAGE[] PROGMEM = R"html(
     <a class='btn btn-secondary me-2' href='/prev'>Prev</a>
     <a class='btn btn-secondary' href='/next'>Next</a>
   </div>
+  <div class='mb-4'>
+    <label for='bright' class='form-label'>Brightness</label>
+    <input type='range' class='form-range' id='bright' min='0' max='255'
+           value='%BRIGHT%'
+           onchange="location.href='/bright?b=' + this.value">
+  </div>
   <ul class="list-group">
   %PRESETS%
   </ul>
@@ -387,6 +393,7 @@ void handleRoot() {
 
   String html = FPSTR(HTML_PAGE);
   html.replace("%PRESETS%", presetList);
+  html.replace("%BRIGHT%", String(brightness));
   server.send(200, "text/html", html);
 }
 
@@ -464,6 +471,24 @@ void handleNext() {
 /** Navigate to previous preset */
 void handlePrev() {
   previousPreset();
+  server.sendHeader("Location", "/");
+  server.send(303);
+}
+
+/** Adjust brightness via query parameter 'b' (0-255) */
+void handleBright() {
+  if (!server.hasArg("b")) {
+    server.send(400, "text/plain", "Missing value");
+    return;
+  }
+  int val = server.arg("b").toInt();
+  if (val < 0 || val > 255) {
+    server.send(400, "text/plain", "Invalid value");
+    return;
+  }
+  brightness = val;
+  FastLED.setBrightness(brightness);
+  applyPreset();
   server.sendHeader("Location", "/");
   server.send(303);
 }
@@ -636,6 +661,7 @@ void setup() {
   server.on("/set", HTTP_GET, handleSet);
   server.on("/next", HTTP_GET, handleNext);
   server.on("/prev", HTTP_GET, handlePrev);
+  server.on("/bright", HTTP_GET, handleBright);
   server.on("/wifi", HTTP_GET, handleWifiForm);
   server.on("/wifi", HTTP_POST, handleWifiSave);
   server.begin();


### PR DESCRIPTION
## Summary
- add a new `/bright` HTTP endpoint to adjust global brightness
- show a brightness slider on the main web page

## Testing
- `cpplint --recursive src include test`
- `./setup.sh` *(fails: include/secrets.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_68441e06e92c8332867f8d32899a80c5