### PR TITLE
Update README with local test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,13 @@ Run the linter after making changes:
 ```bash
 cpplint --recursive src include test
 ```
+
+### Running Tests
+Execute unit tests locally with the `native` environment:
+
+```bash
+pio test -e native
+```
+
+ESP32 environments defined in `platformio.ini` are skipped unless an Arduino
+test skeleton is available.


### PR DESCRIPTION
## Summary
- document how to run the unit tests
- note that ESP32 environments are skipped without an Arduino test skeleton

## Testing
- `pip install platformio`
- `pio test -e native`

------
https://chatgpt.com/codex/tasks/task_e_68442640a2848332bef2e82bfc60cea7