### PR TITLE
Fix cpplint include paths

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,7 +1,7 @@
 // Copyright 2025 Bootj05
 //
 // Licensed under the MIT License.
-#include "utils.h"
+#include "include/utils.h"
 #include <ctype.h>
 #include <stdlib.h>
 #include <string.h>

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -1,6 +1,6 @@
 #include <unity.h>
 // Copyright 2025 Bootj05
-#include "utils.h"
+#include "include/utils.h"
 
 void test_valid_color() {
     uint32_t val;


### PR DESCRIPTION
## Summary
- adjust include paths in `src/utils.cpp` and `test/test_utils.cpp` to satisfy `build/include_subdir`

## Testing
- `cpplint --recursive src include test | head`

------
https://chatgpt.com/codex/tasks/task_e_6844263f59188332a4735ca17dab21d5