### PR TITLE
Fix include guard for Unity config

### DIFF
--- a/include/unity_config.h
+++ b/include/unity_config.h
@@ -1,3 +1,4 @@
-#ifndef UNITY_CONFIG_H
-#define UNITY_CONFIG_H
-#endif
+// Copyright 2025 Bootj05
+#ifndef INCLUDE_UNITY_CONFIG_H_
+#define INCLUDE_UNITY_CONFIG_H_
+#endif  // INCLUDE_UNITY_CONFIG_H_


### PR DESCRIPTION
## Summary
- use `INCLUDE_UNITY_CONFIG_H_` guard in `unity_config.h`
- add repository copyright
- add recommended closing comment

## Testing
- `cpplint --recursive src include test`
- `pio test -e native`


------
https://chatgpt.com/codex/tasks/task_e_6844263afb30833280d08baa36c318ad