### PR TITLE
Fix lint errors and enforce cpplint failures

### DIFF
--- a/.github/workflows/pio.yml
+++ b/.github/workflows/pio.yml
@@ -17,7 +17,7 @@ jobs:
         run: cp include/secrets_example.h include/secrets.h
       - name: Lint sources
         run: |
-          cpplint --recursive src include test || true
+          cpplint --recursive src include test
       - name: Run tests
         run: pio test -e native
       - name: Build firmware

--- a/include/unity_config.h
+++ b/include/unity_config.h
@@ -1,3 +1,5 @@
-#ifndef UNITY_CONFIG_H
-#define UNITY_CONFIG_H
-#endif
+// Copyright 2025 Bootj05
+#ifndef INCLUDE_UNITY_CONFIG_H_
+#define INCLUDE_UNITY_CONFIG_H_
+
+#endif  // INCLUDE_UNITY_CONFIG_H_

--- a/platformio.ini
+++ b/platformio.ini
@@ -6,6 +6,7 @@ platform = espressif32
 board = esp32dev
 framework = arduino
 monitor_speed = 115200
+build_flags = -I.
 lib_deps =
     fastled/FastLED@3.9.20
     links2004/WebSockets
@@ -17,6 +18,7 @@ framework = arduino
 monitor_speed = 115200
 upload_protocol = espota
 upload_port = johannesbril.local
+build_flags = -I.
 lib_deps =
     fastled
     links2004/WebSockets

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,7 +1,7 @@
 // Copyright 2025 Bootj05
 //
 // Licensed under the MIT License.
-#include "utils.h"
+#include "include/utils.h"
 #include <ctype.h>
 #include <stdlib.h>
 #include <string.h>

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -1,6 +1,6 @@
 #include <unity.h>
 // Copyright 2025 Bootj05
-#include "utils.h"
+#include "include/utils.h"
 
 void test_valid_color() {
     uint32_t val;


### PR DESCRIPTION
## Summary
- enforce cpplint failures in CI
- fix cpplint violations in headers and tests
- build firmware after including repo root in include path

## Testing
- `cpplint --recursive src include test`
- `pio test -e native`
- `pio run -e esp32`


------
https://chatgpt.com/codex/tasks/task_e_6844264814208332ade1d150ed44c396