### PR TITLE
Fix shebang for setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Set up PlatformIO and build the firmware
 set -e
 


### PR DESCRIPTION
## Summary
- use `/usr/bin/env bash` in `setup.sh`

## Testing
- `printf 'n\ny\nfoo\nbar\n' | ./setup.sh`
- `printf 'n\ny\nfoo\nbar\nn\nn\n' | ./install.sh`


------
https://chatgpt.com/codex/tasks/task_e_6844264a05e083328a01e4ac38f8ec3f