### PR TITLE
Improve installer error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Pair of specs with magnifier glass upgraded with 13 LEDs.
 
 `python3` and `pip` must be installed before running `setup.sh` or
 `install.sh`. These scripts will install PlatformIO automatically. You
-can use a Python virtual environment if preferred.
+can use a Python virtual environment if preferred. If any command fails
+the scripts report the line number and offending command so problems are
+easy to track down.
 
 ## Firmware
 
@@ -111,7 +113,8 @@ pio run -e esp32-ota --target upload --upload-port <ip_or_hostname>
 Alternatively use `install.sh` to build the project, optionally export the
 compiled binary and flash a connected ESP32 automatically. If
 `include/secrets.h` is missing it will prompt for your WiFi details just like
-`setup.sh`. Both scripts also allow using a virtual environment:
+`setup.sh`. Both scripts also allow using a virtual environment and print
+the failing command when something goes wrong:
 
 ```bash
 ./install.sh

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 # Set up PlatformIO and build the firmware
-set -e
+set -Eeuo pipefail
+
+error_exit() {
+    echo "Error on line $1: $BASH_COMMAND" >&2
+    exit 1
+}
+trap 'error_exit $LINENO' ERR
 
 # Determine sed command and in-place arguments
 SED="sed"
@@ -84,5 +90,11 @@ if [ ! -f include/secrets.h ]; then
 fi
 
 # Build firmware
-pio lib -g install fastled/FastLED@3.9.20
-pio run
+if ! pio lib -g install fastled/FastLED@3.9.20; then
+    echo "Library installation failed" >&2
+    exit 1
+fi
+if ! pio run; then
+    echo "Build failed" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- add fail-fast options and error traps to install.sh and setup.sh
- check for python3 before installing PlatformIO
- bail out on failed library install, build, or flash
- describe the new explicit error reporting in the README

## Testing
- `pio test -e native` *(fails: `pio: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68449afb1da08332bae63d2f06004827