### PR TITLE
Fix presets cleanup order

### DIFF
--- a/src/goggles.ino
+++ b/src/goggles.ino
@@ -112,7 +112,8 @@ struct Preset {
     if (this != &other) {
       delete[] leds;
       delete[] effects;
-      leds = effects = nullptr;
+      leds = nullptr;
+      effects = nullptr;
       name = other.name;
       type = other.type;
       color = other.color;


### PR DESCRIPTION
## Summary
- replace chained assignment with explicit assignments
- verify firmware builds for `esp32` target

## Testing
- `~/.local/bin/platformio run -e esp32`


------
https://chatgpt.com/codex/tasks/task_e_6844c3410f8c8332af647c82229071c4