### PR TITLE
Start AP mode if WiFi connection fails

### DIFF
--- a/src/goggles.ino
+++ b/src/goggles.ino
@@ -205,6 +205,7 @@ uint32_t animInterval = 50;
 bool wifiConnecting = false;
 uint32_t wifiConnectStart = 0;
 uint32_t wifiLastPrint = 0;
+bool wifiApActive = false;
 
 Preferences prefs;
 String storedSSID;
@@ -248,6 +249,7 @@ void connectWiFi() {
       storedHostname.length() ? storedHostname.c_str() : DEFAULT_HOST;
   WiFi.disconnect(true);
   WiFi.mode(WIFI_STA);
+  wifiApActive = false;
   WiFi.begin(ssid, pass);
   wifiConnectStart = millis();
   wifiConnecting = true;
@@ -275,6 +277,14 @@ void handleWiFi() {
   if (millis() - wifiConnectStart > 15000) {
     wifiConnecting = false;
     Serial.println(" failed to connect.");
+    WiFi.mode(WIFI_AP);
+    if (WiFi.softAP(host)) {
+      Serial.print("Started access point ");
+      Serial.print(host);
+      Serial.print(" at ");
+      Serial.println(WiFi.softAPIP());
+    }
+    wifiApActive = true;
     return;
   }
   if (millis() - wifiLastPrint > 500) {


### PR DESCRIPTION
## Summary
- start a soft AP when station mode fails to connect
- retry station mode once credentials are saved

## Testing
- `cpplint --recursive --extensions=cpp,h,ino src include test`
- `pio test -e native`


------
https://chatgpt.com/codex/tasks/task_e_6844c609dd6c8332abc0de8f32ca3166