### PR TITLE
Improve no-port message in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -121,7 +121,7 @@ echo "Searching for connected ESP32 boards..."
 mapfile -t ports < <(pio device list | awk '/tty/ {print $1}')
 
 if [ ${#ports[@]} -eq 0 ]; then
-    echo "No serial ports detected." >&2
+    echo "No serial ports detected. Connect your ESP32 and ensure drivers are installed." >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- notify user about missing ESP32 connection when no serial ports are found

## Testing
- `cpplint --recursive src include test`
- `pio test -e native`

------
https://chatgpt.com/codex/tasks/task_e_6844c5f8ca548332a21137fd27008383