### PR TITLE
Fix library install command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -97,8 +97,8 @@ if [ ! -f include/secrets.h ]; then
     fi
 fi
 
-# Build firmware for esp32 environment
-if ! pio lib -g install fastled/FastLED@3.9.20; then
+# Install FastLED library and build firmware for esp32 environment
+if ! pio pkg install -g fastled/FastLED@3.9.20; then
     echo "Library installation failed" >&2
     exit 1
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -89,8 +89,8 @@ if [ ! -f include/secrets.h ]; then
     fi
 fi
 
-# Build firmware
-if ! pio lib -g install fastled/FastLED@3.9.20; then
+# Install FastLED library and build firmware
+if ! pio pkg install -g fastled/FastLED@3.9.20; then
     echo "Library installation failed" >&2
     exit 1
 fi


### PR DESCRIPTION
## Summary
- use `pio pkg install` for FastLED instead of deprecated `pio lib install`

## Testing
- `cpplint --recursive src include test`
- `pio test -e native`
- `pio run -e esp32` *(fails: cannot convert 'uint8_t*' to 'CRGB*')*

------
https://chatgpt.com/codex/tasks/task_e_6844c5f466f08332a289e9966855056d