### PR TITLE
Fix null assignments in Preset copy operator

### DIFF
--- a/src/goggles.ino
+++ b/src/goggles.ino
@@ -118,7 +118,8 @@ struct Preset {
     if (this != &other) {
       delete[] leds;
       delete[] effects;
-      leds = effects = nullptr;
+      leds = nullptr;
+      effects = nullptr;
       name = other.name;
       type = other.type;
       color = other.color;


### PR DESCRIPTION
## Summary
- fix resetting of `leds` and `effects` pointers in `Preset::operator=`

## Testing
- `cpplint --recursive src include test`
- `pio run`
- `pio test -e native`


------
https://chatgpt.com/codex/tasks/task_e_6844c5f2e2648332966f2b711c2d8d3b