### PR TITLE
Fix preset reset ordering

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -6,6 +6,7 @@ platform = espressif32
 board = esp32dev
 framework = arduino
 monitor_speed = 115200
+board_build.partitions = huge_app.csv
 build_flags = -I.
 lib_deps =
     fastled/FastLED@3.9.20
@@ -18,6 +19,7 @@ framework = arduino
 monitor_speed = 115200
 upload_protocol = espota
 upload_port = johannesbril.local
+board_build.partitions = huge_app.csv
 build_flags = -I.
 lib_deps =
     fastled

--- a/src/goggles.ino
+++ b/src/goggles.ino
@@ -119,8 +119,8 @@ struct Preset {
     if (this != &other) {
       delete[] leds;
       delete[] effects;
-      leds = nullptr;
       effects = nullptr;
+      leds = nullptr;
       name = other.name;
       type = other.type;
       color = other.color;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,7 +1,7 @@
 // Copyright 2025 Bootj05
 //
 // Licensed under the MIT License.
-#include "utils.h"
+#include "include/utils.h"
 #include <ctype.h>
 #include <stdlib.h>
 #include <string.h>

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -1,6 +1,6 @@
 #include <unity.h>
 // Copyright 2025 Bootj05
-#include "utils.h"
+#include "include/utils.h"
 
 // Declarations from test_ws_event.cpp
 void test_next_message();


### PR DESCRIPTION
## Summary
- fix order of pointer resets in `Preset::operator=`
- keep include paths explicit to satisfy cpplint
- expand ESP32 flash partition for build

## Testing
- `cpplint --recursive src include test`
- `pio run -e esp32`


------
https://chatgpt.com/codex/tasks/task_e_6844cbe800c08332b980da92394a5a81