### PR TITLE
Fix wifi password prompt

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -85,7 +85,7 @@ if [ ! -f include/secrets.h ]; then
     if [[ $create_secrets =~ ^[Yy]$ ]]; then
         cp include/secrets_example.h include/secrets.h
         read -p "WiFi SSID: " wifi_ssid
-        read -p "WiFi password: " wifi_pass
+        read -s -p "WiFi password: " wifi_pass; echo
         ssid_escaped=$(escape_sed_replacement "$wifi_ssid")
         pass_escaped=$(escape_sed_replacement "$wifi_pass")
         sed_inplace "s|#define WIFI_SSID .*|#define WIFI_SSID \"${ssid_escaped}\"|" include/secrets.h

--- a/setup.sh
+++ b/setup.sh
@@ -77,7 +77,7 @@ if [ ! -f include/secrets.h ]; then
     if [[ $create_secrets =~ ^[Yy]$ ]]; then
         cp include/secrets_example.h include/secrets.h
         read -p "WiFi SSID: " wifi_ssid
-        read -p "WiFi password: " wifi_pass
+        read -s -p "WiFi password: " wifi_pass; echo
         ssid_escaped=$(escape_sed_replacement "$wifi_ssid")
         pass_escaped=$(escape_sed_replacement "$wifi_pass")
         sed_inplace "s|#define WIFI_SSID .*|#define WIFI_SSID \"${ssid_escaped}\"|" include/secrets.h


### PR DESCRIPTION
## Summary
- show hidden input when entering WiFi password in install/setup scripts

## Testing
- `cpplint --recursive src include test`
- `pio test -e native`
- `pio run -e esp32` *(fails: cannot convert 'uint8_t*' to 'CRGB*')*

------
https://chatgpt.com/codex/tasks/task_e_6844c5f74e7483329dd4930ab8499e22