### PR TITLE
Update FastLED install command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -98,7 +98,7 @@ if [ ! -f include/secrets.h ]; then
 fi
 
 # Build firmware for esp32 environment
-if ! pio pkg install --global fastled/FastLED@3.9.20; then
+if ! pio pkg install --global -l fastled/FastLED@3.9.20; then
     echo "Library installation failed" >&2
     exit 1
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -90,7 +90,7 @@ if [ ! -f include/secrets.h ]; then
 fi
 
 # Build firmware
-if ! pio pkg install --global fastled/FastLED@3.9.20; then
+if ! pio pkg install --global -l fastled/FastLED@3.9.20; then
     echo "Library installation failed" >&2
     exit 1
 fi


### PR DESCRIPTION
## Summary
- fix the FastLED install command in `setup.sh` and `install.sh`

## Testing
- `bash -n setup.sh install.sh`
- `VIRTUAL_ENV="" printf "\n" | ./setup.sh > /dev/null`
- `VIRTUAL_ENV="" printf "\n\n\n" | ./install.sh > /dev/null`

------
https://chatgpt.com/codex/tasks/task_e_6844d099505883329033a8dea00e3c12