### PR TITLE
Add WebSocket command tests

### DIFF
--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -6,6 +6,9 @@
 void test_next_message();
 void test_set_message();
 void test_brightness_message();
+void test_color_message();
+void test_speed_message();
+void test_leds_message();
 
 void test_valid_color() {
     uint32_t val;
@@ -31,6 +34,9 @@ int main(int argc, char **argv) {
     RUN_TEST(test_next_message);
     RUN_TEST(test_set_message);
     RUN_TEST(test_brightness_message);
+    RUN_TEST(test_color_message);
+    RUN_TEST(test_speed_message);
+    RUN_TEST(test_leds_message);
     return UNITY_END();
 }
 

--- a/test/test_ws_event.cpp
+++ b/test/test_ws_event.cpp
@@ -4,13 +4,20 @@
 #include <vector>
 #include <cstdint>
 #include <cstdlib>
+#include "include/utils.h"
 
 // Minimal stand-ins for firmware globals and helpers
-struct Preset {};
+constexpr size_t NUM_LEDS = 13;
+struct Preset {
+    uint32_t color{};
+    std::vector<uint32_t> leds;
+    Preset() : color(0), leds(NUM_LEDS, 0) {}
+};
 
 static std::vector<Preset> presets;
 static int currentPreset = 0;
 static uint8_t brightness = 255;
+static uint32_t animInterval = 50;
 static bool applyCalled = false;
 
 static void applyPreset() {
@@ -57,6 +64,43 @@ static void wsEvent(uint8_t /*num*/, WStype_t type, uint8_t *payload,
                 applyPreset();
             }
         }
+    } else if (msg.rfind("color:", 0) == 0) {
+        std::string colorStr = msg.substr(6);
+        if (colorStr.size() == 7 && colorStr[0] == '#') {
+            colorStr.erase(0, 1);
+            uint32_t val;
+            if (parseHexColor(colorStr.c_str(), val)) {
+                presets[currentPreset].color = val;
+                applyPreset();
+            }
+        }
+    } else if (msg.rfind("speed:", 0) == 0) {
+        std::string valStr = msg.substr(6);
+        if (!valStr.empty() &&
+            valStr.find_first_not_of("0123456789") == std::string::npos) {
+            int val = std::stoi(valStr);
+            if (val > 0)
+                animInterval = static_cast<uint32_t>(val);
+        }
+    } else if (msg.rfind("leds:", 0) == 0) {
+        std::string data = msg.substr(5);
+        presets[currentPreset].leds.assign(NUM_LEDS, 0);
+        size_t idx = 0;
+        while (idx < NUM_LEDS && !data.empty()) {
+            size_t sep = data.find(',');
+            std::string tok = sep == std::string::npos ? data : data.substr(0, sep);
+            if (!tok.empty() && tok[0] == '#')
+                tok.erase(0, 1);
+            uint32_t val;
+            if (parseHexColor(tok.c_str(), val))
+                presets[currentPreset].leds[idx] = val;
+            if (sep == std::string::npos)
+                data.clear();
+            else
+                data.erase(0, sep + 1);
+            ++idx;
+        }
+        applyPreset();
     }
 }
 
@@ -64,6 +108,7 @@ void setUp(void) {
     presets.assign(3, Preset());
     currentPreset = 0;
     brightness = 255;
+    animInterval = 50;
     applyCalled = false;
 }
 
@@ -87,6 +132,31 @@ void test_brightness_message() {
     auto buf = reinterpret_cast<uint8_t *>(const_cast<char *>(msg));
     wsEvent(0, WStype_TEXT, buf, sizeof(msg) - 1);
     TEST_ASSERT_EQUAL_UINT8(128, brightness);
+    TEST_ASSERT_TRUE(applyCalled);
+}
+
+void test_color_message() {
+    const char msg[] = "color:#112233";
+    auto buf = reinterpret_cast<uint8_t *>(const_cast<char *>(msg));
+    wsEvent(0, WStype_TEXT, buf, sizeof(msg) - 1);
+    TEST_ASSERT_EQUAL_HEX32(0x112233, presets[currentPreset].color);
+    TEST_ASSERT_TRUE(applyCalled);
+}
+
+void test_speed_message() {
+    const char msg[] = "speed:123";
+    auto buf = reinterpret_cast<uint8_t *>(const_cast<char *>(msg));
+    wsEvent(0, WStype_TEXT, buf, sizeof(msg) - 1);
+    TEST_ASSERT_EQUAL_UINT32(123, animInterval);
+}
+
+void test_leds_message() {
+    const char msg[] = "leds:#010203,#a0b0c0,#ffffff";
+    auto buf = reinterpret_cast<uint8_t *>(const_cast<char *>(msg));
+    wsEvent(0, WStype_TEXT, buf, sizeof(msg) - 1);
+    TEST_ASSERT_EQUAL_HEX32(0x010203, presets[currentPreset].leds[0]);
+    TEST_ASSERT_EQUAL_HEX32(0xa0b0c0, presets[currentPreset].leds[1]);
+    TEST_ASSERT_EQUAL_HEX32(0xffffff, presets[currentPreset].leds[2]);
     TEST_ASSERT_TRUE(applyCalled);
 }
 


### PR DESCRIPTION
## Summary
- extend `wsEvent` mock to handle `color`, `speed`, and `leds` commands
- test that these commands correctly update preset color, animation speed and LED data
- run new tests in `test_utils.cpp`

## Testing
- `pio test -e native`

------
https://chatgpt.com/codex/tasks/task_e_684553e0e4f08332a448bc82308e7c63