### PR TITLE
Add huge_app partition config for ESP32

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -7,6 +7,7 @@ board = esp32dev
 framework = arduino
 monitor_speed = 115200
 build_flags = -I.
+board_build.partitions = huge_app.csv
 lib_deps =
     fastled/FastLED@3.9.20
     links2004/WebSockets
@@ -19,6 +20,7 @@ monitor_speed = 115200
 upload_protocol = espota
 upload_port = johannesbril.local
 build_flags = -I.
+board_build.partitions = huge_app.csv
 lib_deps =
     fastled
     links2004/WebSockets


### PR DESCRIPTION
## Summary
- specify `board_build.partitions = huge_app.csv` for the esp32 and esp32-ota environments

## Testing
- `pio run -e esp32` *(fails: `pio` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845593907048332a3895ddaff63b9a2