### PR TITLE
Add pin and hostname prompts to install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ pio run --target upload
 ### OTA updates
 Once the firmware has been flashed at least once you can upload new
 versions over WiFi. The `esp32-ota` PlatformIO environment is configured
-for OTA using the default mDNS host `JohannesBril.local`.
+for OTA using the default mDNS host `JohannesBril.local` (or the hostname
+chosen during installation).
 
 ```bash
 pio run -e esp32-ota --target upload
@@ -138,6 +139,10 @@ Use a Python virtual environment? [y/N]
 Create include/secrets.h now? [y/N]
 WiFi SSID: <your_ssid>
 WiFi password: <hidden>
+LED pin (default 2): 2
+Previous button pin (default 0): 0
+Next button pin (default 35): 35
+mDNS hostname (default JohannesBril): MyGoggles
 Export firmware binary to firmware.bin? [y/N]
 Searching for connected ESP32 boards...
 1) /dev/ttyUSB0

--- a/install.sh
+++ b/install.sh
@@ -97,6 +97,21 @@ if [ ! -f include/secrets.h ]; then
     fi
 fi
 
+# Allow user to override hardware pins and hostname
+read -p "LED pin (default 2): " led_pin
+led_pin=${led_pin:-2}
+read -p "Previous button pin (default 0): " btn_prev
+btn_prev=${btn_prev:-0}
+read -p "Next button pin (default 35): " btn_next
+btn_next=${btn_next:-35}
+read -p "mDNS hostname (default JohannesBril): " mdns_name
+mdns_name=${mdns_name:-JohannesBril}
+mdns_escaped=$(escape_sed_replacement "$mdns_name")
+sed_inplace "s|constexpr uint8_t LED_PIN = .*;|constexpr uint8_t LED_PIN = ${led_pin};|" src/goggles.ino
+sed_inplace "s|constexpr uint8_t BTN_PREV = .*;|constexpr uint8_t BTN_PREV = ${btn_prev};|" src/goggles.ino
+sed_inplace "s|constexpr uint8_t BTN_NEXT = .*;|constexpr uint8_t BTN_NEXT = ${btn_next};|" src/goggles.ino
+sed_inplace "s|constexpr char DEFAULT_HOST\[] = \".*\";|constexpr char DEFAULT_HOST[] = \"${mdns_escaped}\";|" src/goggles.ino
+
 # Build firmware for esp32 environment
 if ! pio pkg install --global -l fastled/FastLED@3.9.20; then
     echo "Library installation failed" >&2


### PR DESCRIPTION
## Summary
- allow choosing LED and button pins during install
- support specifying the mDNS hostname when flashing
- document new prompts and clarify default hostname in README

## Testing
- `cpplint --recursive src include test`
- `pio test -e native`

------
https://chatgpt.com/codex/tasks/task_e_684692eca3c08332ae7934b99d078c35