### PR TITLE
Fix Windows port detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -118,7 +118,7 @@ fi
 
 # Search for ESP32 serial ports
 echo "Searching for connected ESP32 boards..."
-mapfile -t ports < <(pio device list | awk '/tty/ {print $1}')
+mapfile -t ports < <(pio device list | awk '/tty|COM/ {print $1}')
 
 if [ ${#ports[@]} -eq 0 ]; then
     echo "No serial ports detected. Connect your ESP32 and ensure drivers are installed." >&2


### PR DESCRIPTION
## Summary
- match both `/tty` and `COM` serial devices in `install.sh`

## Testing
- `pio test -e native`

------
https://chatgpt.com/codex/tasks/task_e_68469867e4148332b984d33a1da96a40