### PR TITLE
Fix library installs in helper scripts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -98,7 +98,9 @@ if [ ! -f include/secrets.h ]; then
 fi
 
 # Build firmware for esp32 environment
-if ! pio pkg install --global -l fastled/FastLED@3.9.20; then
+if ! pio pkg install --global \
+        -l fastled/FastLED@3.9.20 \
+        -l links2004/WebSockets; then
     echo "Library installation failed" >&2
     exit 1
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -90,7 +90,9 @@ if [ ! -f include/secrets.h ]; then
 fi
 
 # Build firmware
-if ! pio pkg install --global -l fastled/FastLED@3.9.20; then
+if ! pio pkg install --global \
+        -l fastled/FastLED@3.9.20 \
+        -l links2004/WebSockets; then
     echo "Library installation failed" >&2
     exit 1
 fi


### PR DESCRIPTION
## Summary
- ensure setup and install scripts install both FastLED and WebSockets

## Testing
- `cpplint --recursive src include test`
- `pio test -e native`
- `./setup.sh <<EOF
n
EOF`
- `pio run`
- `./install.sh <<EOF
n
n
EOF` *(fails: No serial ports detected)*
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_684698715d2883329587f7b240a6b6fd