### PR TITLE
Refactor parseHexColor for MISRA compliance

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -3,17 +3,32 @@
 // Licensed under the MIT License.
 #include "include/utils.h"
 
-#include <ctype.h>
-#include <stdlib.h>
-#include <string.h>
+#include <stddef.h>
 
 bool parseHexColor(const char *hex, uint32_t &value) {
-    if (!hex || strlen(hex) != 6)
+    if (hex == nullptr) {
         return false;
-    for (size_t i = 0; i < 6; ++i) {
-        if (!isxdigit(static_cast<unsigned char>(hex[i])))
-            return false;
     }
-    value = strtoul(hex, nullptr, 16);
+    uint32_t result = 0U;
+    for (size_t i = 0U; i < 6U; ++i) {
+        char c = hex[i];
+        if (c == '\0') {
+            return false;
+        }
+        result <<= 4U;
+        if (c >= '0' && c <= '9') {
+            result |= static_cast<uint32_t>(c - '0');
+        } else if (c >= 'a' && c <= 'f') {
+            result |= static_cast<uint32_t>(c - 'a' + 10);
+        } else if (c >= 'A' && c <= 'F') {
+            result |= static_cast<uint32_t>(c - 'A' + 10);
+        } else {
+            return false;
+        }
+    }
+    if (hex[6] != '\0') {
+        return false;
+    }
+    value = result;
     return true;
 }


### PR DESCRIPTION
## Summary
- avoid using standard library parsing in `parseHexColor`
- implement manual hex parser to simplify dependencies

## Testing
- `cpplint --recursive src include test`
- `pio test -e native` *(fails: `pio: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847cef5588c8332b1e1c2932c1bdae7