### PR TITLE
Fix include path

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,1 +1,2 @@
 extensions=cpp,h,ino
+filter=-build/include_subdir

--- a/src/goggles.ino
+++ b/src/goggles.ino
@@ -22,7 +22,7 @@
 #include <BluetoothSerial.h>
 
 #include "secrets.h"  // NOLINT(build/include_subdir)
-#include "include/utils.h"
+#include "utils.h"
 
 #ifndef KEEP_NAMES_IN_FLASH
 #define KEEP_NAMES_IN_FLASH 0

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,7 +1,7 @@
 // Copyright 2025 Bootj05
 //
 // Licensed under the MIT License.
-#include "include/utils.h"
+#include "utils.h"
 
 #include <stddef.h>
 

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -1,6 +1,6 @@
 #include <unity.h>
 // Copyright 2025 Bootj05
-#include "include/utils.h"
+#include "utils.h"
 
 // Declarations from test_ws_event.cpp
 void test_next_message();

--- a/test/test_ws_event.cpp
+++ b/test/test_ws_event.cpp
@@ -4,7 +4,7 @@
 #include <vector>
 #include <cstdint>
 #include <cstdlib>
-#include "include/utils.h"
+#include "utils.h"
 
 // Minimal stand-ins for firmware globals and helpers
 constexpr size_t NUM_LEDS = 13;


### PR DESCRIPTION
## Summary
- use `utils.h` directly instead of `include/utils.h`
- disable `build/include_subdir` rule in cpplint

## Testing
- `cpplint --recursive src include test`
- `pio test -e native`

------
https://chatgpt.com/codex/tasks/task_e_6847dcf2d9e08332a3db79c60f83f563