### PR TITLE
Improve WiFi config page

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ expects a `token` parameter and WebSocket commands must be prefixed with
 - OTA updates over WiFi
 - Simple WebSocket API for remote control
 - Bluetooth serial control with the same commands
-- Runtime WiFi configuration at `/wifi` (SSID, password and device name)
+- Runtime WiFi configuration at `/wifi` (SSID, password and device name, form pre-filled with stored values)
 - Custom mDNS hostname
 - Per-LED custom colors stored as a new `CUSTOM` preset
 

--- a/src/goggles.ino
+++ b/src/goggles.ino
@@ -817,17 +817,22 @@ const char WIFI_FORM_HTML[] PROGMEM = R"html(
 <h1 class='mb-3'>WiFi Credentials</h1>
 <form method='POST' action='/wifi' class='row g-3'>
 <div class='col-12'><label class='form-label' for='ssid'>SSID</label>
-<input class='form-control' id='ssid' name='ssid'></div>
+<input class='form-control' id='ssid' name='ssid' value='%SSID%'></div>
 <div class='col-12'><label class='form-label' for='password'>Password</label>
 <input class='form-control' id='password' name='password' type='password'></div>
 <div class='form-group'><label for='host'>Device name</label>
-<input class='form-control' id='host' name='host'></div>
+<input class='form-control' id='host' name='host' value='%HOST%'></div>
 <button class='btn btn-primary'>Save</button></form>
 </body></html>
 )html";
 
 void handleWifiForm() {
-  server.send_P(200, "text/html", WIFI_FORM_HTML);
+  loadCredentials();
+  String html = FPSTR(WIFI_FORM_HTML);
+  String host = storedHostname.length() ? storedHostname : DEFAULT_HOST;
+  html.replace("%SSID%", storedSSID);
+  html.replace("%HOST%", host);
+  server.send(200, "text/html", html);
 }
 
 /**

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -17,6 +17,7 @@ void test_brightness_invalid();
 void test_speed_invalid();
 void test_speed_nonnumeric();
 void test_leds_bad_data();
+void test_wifi_form_hostname();
 
 void test_valid_color() {
     uint32_t val;
@@ -66,6 +67,7 @@ int main(int argc, char **argv) {
     RUN_TEST(test_speed_invalid);
     RUN_TEST(test_speed_nonnumeric);
     RUN_TEST(test_leds_bad_data);
+    RUN_TEST(test_wifi_form_hostname);
     return UNITY_END();
 }
 

--- a/test/test_wifi_form.cpp
+++ b/test/test_wifi_form.cpp
@@ -1,0 +1,46 @@
+#include <unity.h>
+// Copyright 2025 Bootj05
+#include <string>
+
+static std::string storedSSID;      // NOLINT(runtime/string)
+static std::string storedHostname;  // NOLINT(runtime/string)
+static bool loadCalled;
+
+void loadCredentials() {
+    loadCalled = true;
+}
+
+struct DummyServer {
+    std::string body;
+    void send(int /*code*/, const char* /*type*/, const std::string& html) {
+        body = html;
+    }
+};
+
+static DummyServer server;
+
+const char WIFI_FORM_HTML[] =
+    "<input id='ssid' value='%SSID%'><input id='host' value='%HOST%'>";
+
+void handleWifiForm() {
+    loadCredentials();
+    std::string html = WIFI_FORM_HTML;
+    size_t pos = html.find("%SSID%");
+    if (pos != std::string::npos)
+        html.replace(pos, 6, storedSSID);
+    pos = html.find("%HOST%");
+    if (pos != std::string::npos)
+        html.replace(pos, 6, storedHostname);
+    server.send(200, "text/html", html);
+}
+
+void test_wifi_form_hostname() {
+    storedSSID = "MyNet";
+    storedHostname = "MyGoggles";
+    loadCalled = false;
+    handleWifiForm();
+    TEST_ASSERT_TRUE(loadCalled);
+    TEST_ASSERT_NOT_EQUAL(std::string::npos,
+                          server.body.find(storedHostname));
+}
+


### PR DESCRIPTION
## Summary
- embed SSID and hostname values into WiFi form
- show stored values in the form
- test WiFi form HTML output

## Testing
- `cpplint --recursive src include test`
- `pio test -e native`

------
https://chatgpt.com/codex/tasks/task_e_684833972acc8332b35b251551062bc6