### PR TITLE
Update WiFi form handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ expects a `token` parameter and WebSocket commands must be prefixed with
 - OTA updates over WiFi
 - Simple WebSocket API for remote control
 - Bluetooth serial control with the same commands
-- Runtime WiFi configuration at `/wifi` (SSID, password and device name)
+- Runtime WiFi configuration at `/wifi` (form pre-filled with stored SSID and device name)
 - Custom mDNS hostname
 - Per-LED custom colors stored as a new `CUSTOM` preset
 

--- a/src/goggles.ino
+++ b/src/goggles.ino
@@ -817,17 +817,21 @@ const char WIFI_FORM_HTML[] PROGMEM = R"html(
 <h1 class='mb-3'>WiFi Credentials</h1>
 <form method='POST' action='/wifi' class='row g-3'>
 <div class='col-12'><label class='form-label' for='ssid'>SSID</label>
-<input class='form-control' id='ssid' name='ssid'></div>
+<input class='form-control' id='ssid' name='ssid' value='%SSID%'></div>
 <div class='col-12'><label class='form-label' for='password'>Password</label>
 <input class='form-control' id='password' name='password' type='password'></div>
 <div class='form-group'><label for='host'>Device name</label>
-<input class='form-control' id='host' name='host'></div>
+<input class='form-control' id='host' name='host' value='%HOST%'></div>
 <button class='btn btn-primary'>Save</button></form>
 </body></html>
 )html";
 
 void handleWifiForm() {
-  server.send_P(200, "text/html", WIFI_FORM_HTML);
+  loadCredentials();
+  String html = FPSTR(WIFI_FORM_HTML);
+  html.replace("%SSID%", storedSSID);
+  html.replace("%HOST%", storedHostname);
+  server.send(200, "text/html", html);
 }
 
 /**

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -17,6 +17,7 @@ void test_brightness_invalid();
 void test_speed_invalid();
 void test_speed_nonnumeric();
 void test_leds_bad_data();
+void test_wifi_form_hostname();
 
 void test_valid_color() {
     uint32_t val;
@@ -66,6 +67,7 @@ int main(int argc, char **argv) {
     RUN_TEST(test_speed_invalid);
     RUN_TEST(test_speed_nonnumeric);
     RUN_TEST(test_leds_bad_data);
+    RUN_TEST(test_wifi_form_hostname);
     return UNITY_END();
 }
 

--- a/test/test_wifi_form.cpp
+++ b/test/test_wifi_form.cpp
@@ -1,0 +1,23 @@
+#include <unity.h>
+// Copyright 2025 Bootj05
+#include <string>
+
+static std::string renderWifiForm(const std::string &tpl,
+                                  const std::string &ssid,
+                                  const std::string &host) {
+    std::string html = tpl;
+    size_t pos;
+    while ((pos = html.find("%SSID%")) != std::string::npos)
+        html.replace(pos, 6, ssid);
+    while ((pos = html.find("%HOST%")) != std::string::npos)
+        html.replace(pos, 6, host);
+    return html;
+}
+
+void test_wifi_form_hostname() {
+    const std::string tpl =
+        "<input id='ssid' value='%SSID%'><input id='host' value='%HOST%'>";
+    std::string html = renderWifiForm(tpl, "mySSID", "MyDevice");
+    TEST_ASSERT_NOT_EQUAL(std::string::npos, html.find("MyDevice"));
+}
+


### PR DESCRIPTION
## Summary
- prefill WiFi form with stored SSID and hostname
- document new WiFi form behaviour
- add unit test for WiFi form generation

## Testing
- `cpplint --recursive src include test`
- `pip install platformio`
- `pio test -e native`

------
https://chatgpt.com/codex/tasks/task_e_684834bf7c708332a3e4a992213a2023