### PR TITLE
Add configurable hold button support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,14 @@ expects a `token` parameter and WebSocket commands must be prefixed with
 - Runtime WiFi configuration at `/wifi` (SSID, password and device name)
 - Custom mDNS hostname
 - Per-LED custom colors stored as a new `CUSTOM` preset
+- Configurable "hold" button to temporarily switch to a preset
 
 ### Hardware
 The previous and next buttons are wired as active-low. Pins 34--39 on the
 ESP32 can't use internal pull-ups, so if you connect a button to one of those
 pins (e.g. GPIO35) make sure an external pull-up resistor is present.
+Pin 17 is used for the optional "hold" button which temporarily activates a
+preset of your choice.
 
 ### WebSocket API
 The firmware also runs a WebSocket server on port `81`. Send plain text commands
@@ -159,6 +162,7 @@ LED pin (default 2): 2
 Previous button pin (default 0): 0
 Next button pin (default 35): 35
 mDNS hostname (default JohannesBril): MyGoggles
+Hold button pin (default 17): 17
 Export firmware binary to firmware.bin? [y/N]
 Searching for connected ESP32 boards...
 1) /dev/ttyUSB0

--- a/install.sh
+++ b/install.sh
@@ -160,6 +160,7 @@ if [ "$NON_INTERACTIVE" = true ]; then
     btn_prev=0
     btn_next=35
     mdns_name=JohannesBril
+    btn_hold=17
 else
     read -p "LED pin (default 2): " led_pin
     led_pin=${led_pin:-2}
@@ -169,11 +170,14 @@ else
     btn_next=${btn_next:-35}
     read -p "mDNS hostname (default JohannesBril): " mdns_name
     mdns_name=${mdns_name:-JohannesBril}
+    read -p "Hold button pin (default 17): " btn_hold
+    btn_hold=${btn_hold:-17}
 fi
 mdns_escaped=$(escape_sed_replacement "$mdns_name")
 sed_inplace "s|constexpr uint8_t LED_PIN = .*;|constexpr uint8_t LED_PIN = ${led_pin};|" src/goggles.ino
 sed_inplace "s|constexpr uint8_t BTN_PREV = .*;|constexpr uint8_t BTN_PREV = ${btn_prev};|" src/goggles.ino
 sed_inplace "s|constexpr uint8_t BTN_NEXT = .*;|constexpr uint8_t BTN_NEXT = ${btn_next};|" src/goggles.ino
+sed_inplace "s|constexpr uint8_t BTN_HOLD = .*;|constexpr uint8_t BTN_HOLD = ${btn_hold};|" src/goggles.ino
 sed_inplace "s|constexpr char DEFAULT_HOST\[] = \".*\";|constexpr char DEFAULT_HOST[] = \"${mdns_escaped}\";|" src/goggles.ino
 
 # Build firmware for esp32 environment


### PR DESCRIPTION
## Summary
- allow specifying a hold button pin in firmware
- support storing a hold preset
- expose hold preset selection on the web UI
- add hold button options in install script and docs

## Testing
- `./setup.sh --non-interactive`
- `pio test -e native`

------
https://chatgpt.com/codex/tasks/task_e_684832a9e1548332a26765d8556cfe6c